### PR TITLE
Enhancement/folder default

### DIFF
--- a/BADGE_CONFIGURATIONS.md
+++ b/BADGE_CONFIGURATIONS.md
@@ -2,13 +2,13 @@
 
 ### Build Status badges
 
-* [buildStatus badge from nikitas-badges](https://www.npmjs.com/package/nikitas-badges)
+* [buildStatus badge from nikitas-badges](https://www.npmjs.com/package/nikitas-badges#buildstatus)
   * [![](https://raw.githubusercontent.com/nikita-skobov/nikitas-badges/8c09a3e5e7ff800c5ce00c38d96beab97a2ff36d/examples/buildStatus/passing.svg?sanitize=true)](https://raw.githubusercontent.com/nikita-skobov/nikitas-badges/8c09a3e5e7ff800c5ce00c38d96beab97a2ff36d/examples/buildStatus/passing.svg?sanitize=true)
   * [![](https://raw.githubusercontent.com/nikita-skobov/nikitas-badges/master/examples/buildStatus/failing.svg?sanitize=true)](https://raw.githubusercontent.com/nikita-skobov/nikitas-badges/master/examples/buildStatus/failing.svg?sanitize=true)
 
 ### Code Coverage badges
 
-* [cloverCoverage badge from nikitas-badges](https://www.npmjs.com/package/nikitas-badges)
+* [cloverCoverage badge from nikitas-badges](https://www.npmjs.com/package/nikitas-badges#clovercoverage)
   * [![](https://raw.githubusercontent.com/nikita-skobov/nikitas-badges/master/examples/cloverCoverage/coverage-high.svg?sanitize=true)](https://raw.githubusercontent.com/nikita-skobov/nikitas-badges/master/examples/cloverCoverage/coverage-high.svg?sanitize=true)
   * [![](https://raw.githubusercontent.com/nikita-skobov/nikitas-badges/master/examples/cloverCoverage/coverage-medium.svg?sanitize=true)](https://raw.githubusercontent.com/nikita-skobov/nikitas-badges/master/examples/cloverCoverage/coverage-medium.svg?sanitize=true)
   * [![](https://raw.githubusercontent.com/nikita-skobov/nikitas-badges/master/examples/cloverCoverage/coverage-low.svg?sanitize=true)](https://raw.githubusercontent.com/nikita-skobov/nikitas-badges/master/examples/cloverCoverage/coverage-low.svg?sanitize=true)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ module.exports = {
       // this badge will be different depending on whether or not
       // you pass in a --successFlag option when running local-badges
       name: 'build-status',
-      folder: './',
       fn: (cliObj) => {
         const colorB = cliObj.successFlag ? 'green' : 'red'
         const passOrFail = cliObj.successFlag ? 'passing' : 'failing'
@@ -110,6 +109,7 @@ module.exports = {
   // eg: build-status
   defaults: {
     colorA: 'purple',
+    folder: './badges',
   },
 }
 ```
@@ -121,10 +121,11 @@ The first badge will be named `boring-badge.svg` and it will be placed in your c
   folder: './'
 }
 ```
-The second badge will be named `build-status.svg`, and will also be placed in your current working directory. the build-status badge has an extra property in the badge object called `fn`. `fn` is a function that takes a cli object that contains all the arguments passed in to local-badges. You can customize your badge configuration to depend on any argument you want other than `--config` because local-badges uses `--config` to find your configuration file.
+The second badge will be named `build-status.svg`, and this badge will be placed in a folder called badges because this badge object does not contain a folder property, therefore the default folder: ./badges is used. The build-status badge has an extra property in the badge object called `fn`. `fn` is a function that takes a cli object that contains all the arguments passed in to local-badges. You can customize your badge configuration to depend on any argument you want other than `--config` because local-badges uses `--config` to find your configuration file.
 
 ## Global defaults (as found in [lib/constants/defaults.js](./lib/constants/defaults.js)):
 - format: 'svg'
+- folder: './'
 - colorA: 'gray'
 - colorB: 'lightgray'
 - template: 'flat'
@@ -177,6 +178,11 @@ text: (the text on the badge)
   - both element must be strings
   - if you want a badge that is a single color, you can make the first element be an empty string.
 
+folder: (the output folder of the badges)
+  - optional
+  - string
+  - defaults to current working directory
+
 ## valid badge object properties:
 
 All of the properties from the defaults object above can also be included in your badge object(s) to override the defaults specifically for that badge. In addition to the default properties, the badge object also takes the following properties:
@@ -185,10 +191,6 @@ name: (the name of the file to be output)
   - required
   - string
   - the format extension will be appended automatically
-
-folder: (the path or name of the folder where this badge will go)
-  - required
-  - string
 
 fn: (a function that gets invoked by the badgeRunner that lets you customize your badge dynamically via the inputs from the command line)
   - optional

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ module.exports = {
   badges: [
     {
       name: 'my-badge', // required
-      folder: './', // required
+      folder: './badges', // optional, defaults to current working directory
       colorA: 'yellow', // optional, defaults to gray
       colorB: 'red', // optional, defaults to lightgray
       template: 'plastic', // optional, defaults to flat
@@ -33,7 +33,7 @@ module.exports = {
 }
 ```
 
-The above example will create a badge named my-badge.svg in the current working directory. It will look like this:
+The above example will create a badge named my-badge.svg in a new folder called badges. It will look like this:
 
 [![yellow-plastic-red](testFolder/yellow-red-plastic.svg)](testFolder/yellow-red-plastic.svg)
 
@@ -121,7 +121,7 @@ The first badge will be named `boring-badge.svg` and it will be placed in your c
   folder: './'
 }
 ```
-The second badge will be named `build-status.svg`, and this badge will be placed in a folder called badges because this badge object does not contain a folder property, therefore the default folder: ./badges is used. The build-status badge has an extra property in the badge object called `fn`. `fn` is a function that takes a cli object that contains all the arguments passed in to local-badges. You can customize your badge configuration to depend on any argument you want other than `--config` because local-badges uses `--config` to find your configuration file.
+The second badge will be named `build-status.svg`, and this badge will be placed in a folder called badges because this badge object does not contain a folder property, therefore local-badges uses the defaults that are specified above. The build-status badge has an extra property in the badge object called `fn`. `fn` is a function that takes a cli object that contains all the arguments passed in to local-badges. You can customize your badge configuration to depend on any argument you want other than `--config` because local-badges uses `--config` to find your configuration file.
 
 ## Global defaults (as found in [lib/constants/defaults.js](./lib/constants/defaults.js)):
 - format: 'svg'
@@ -135,7 +135,7 @@ The second badge will be named `build-status.svg`, and this badge will be placed
 
 ```js
 module.exports = {
-  defaults: { 
+  defaults: {
   // defaults: Object, optional. if no 'defaults' property is present
   // local-badges will use the global defaults
   // any defaults you specify here will override the global defaults.

--- a/badgeConfig.js
+++ b/badgeConfig.js
@@ -1,4 +1,4 @@
-const folder = './badges'
+const folder = './badges2'
 const fs = require('fs')
 
 function getMainMetricSnippet(str) {
@@ -27,12 +27,10 @@ module.exports = {
   badges: [
     {
       name: 'boring-default-badge',
-      folder,
     },
     {
       // I made this specifically for the jest clover.xml report
       name: 'coverage',
-      folder,
       fn: (cliObj) => {
         const coveragePath = cliObj['coverage-path']
         const cloverData = fs.readFileSync(coveragePath, { encoding: 'UTF-8' })
@@ -78,7 +76,6 @@ module.exports = {
     {
       // build status can just come from a flag
       name: 'build-status',
-      folder,
       fn: (cliObj) => {
         const returnObj = {
           text: ['build', 'failing'],
@@ -94,5 +91,6 @@ module.exports = {
   ],
   defaults: {
     colorA: 'grey',
+    folder,
   },
 }

--- a/badgeConfig.js
+++ b/badgeConfig.js
@@ -1,4 +1,4 @@
-const folder = './badges2'
+const folder = './badges'
 const fs = require('fs')
 
 function getMainMetricSnippet(str) {

--- a/lib/badgeRunner.js
+++ b/lib/badgeRunner.js
@@ -18,7 +18,7 @@ function overrideState(originalState, newState) {
 
   if (getRealType(newState) === 'object') {
     Object.keys(newState).forEach((key) => {
-      if (key !== FUNCTION_KEY && key !== FILE_KEY && key !== FOLDER_KEY) {
+      if (key !== FUNCTION_KEY && key !== FILE_KEY) {
         tempState[key] = newState[key]
       }
     })

--- a/lib/badgeRunner.js
+++ b/lib/badgeRunner.js
@@ -1,6 +1,5 @@
 const {
   FUNCTION_KEY,
-  FOLDER_KEY,
   FILE_KEY,
 } = require('./constants/defaults')
 const {

--- a/lib/badgeRunner.test.js
+++ b/lib/badgeRunner.test.js
@@ -79,19 +79,6 @@ describe('badgeRunner module', () => {
       const newState = overrideState(inputA, inputBWithFileKey)
       expect(newState).toEqual(expectedObj)
     })
-    it('should not copy the FOLDER_KEY if present in inputB', () => {
-      const expectedObj = {
-        test: 'no',
-        hello: 'world2',
-        something: 'else',
-      }
-      const inputBWithFolderKey = {
-        ...inputB,
-        [FOLDER_KEY]: './someFolder/',
-      }
-      const newState = overrideState(inputA, inputBWithFolderKey)
-      expect(newState).toEqual(expectedObj)
-    })
   })
 
   describe('badgeRunner function', () => {

--- a/lib/badgeRunner.test.js
+++ b/lib/badgeRunner.test.js
@@ -190,7 +190,6 @@ describe('badgeRunner module', () => {
         badges: [
           {
             [FILE_KEY]: 'some-file',
-            [FOLDER_KEY]: 'some-folder',
           },
         ],
       }
@@ -201,7 +200,6 @@ describe('badgeRunner module', () => {
     it('should call the makeBadgeFunc with the badge and the badge state', () => {
       const badgeObj = {
         [FILE_KEY]: 'some-file',
-        [FOLDER_KEY]: 'some-folder',
       }
       const state = {
         colorA: '#aaa',
@@ -209,6 +207,7 @@ describe('badgeRunner module', () => {
         format: 'svg',
         template: 'flat',
         text: ['a', 'b'],
+        [FOLDER_KEY]: './',
       }
       const configObj7 = {
         defaults: state,

--- a/lib/constants/defaults.js
+++ b/lib/constants/defaults.js
@@ -1,4 +1,8 @@
 const DEFAULT_CONFIG_NAME = 'badgeConfig.js'
+const FUNCTION_KEY = 'fn'
+const FILE_KEY = 'name'
+const FOLDER_KEY = 'folder'
+
 const DEFAULT_STATE = {
   format: 'svg', // can be svg only for now
   colorA: 'gray', // left side of badge
@@ -18,7 +22,8 @@ const DEFAULT_STATE = {
     'boring', // if first text element is empty string
     'badge', // it makes badge with colorB only
   ],
-  folder: './',
+
+  [FOLDER_KEY]: './',
 }
 
 const ALLOWED_TEMPLATES = [
@@ -35,10 +40,6 @@ const ALLOWED_TEMPLATES = [
 const ALLOWED_FORMATS = [
   'svg',
 ]
-
-const FUNCTION_KEY = 'fn'
-const FILE_KEY = 'name'
-const FOLDER_KEY = 'folder'
 
 module.exports = {
   DEFAULT_CONFIG_NAME,

--- a/lib/constants/defaults.js
+++ b/lib/constants/defaults.js
@@ -18,6 +18,7 @@ const DEFAULT_STATE = {
     'boring', // if first text element is empty string
     'badge', // it makes badge with colorB only
   ],
+  folder: './',
 }
 
 const ALLOWED_TEMPLATES = [

--- a/lib/makeBadge.js
+++ b/lib/makeBadge.js
@@ -10,9 +10,9 @@ const bf = new BadgeFactory()
 function makeBadge(badge, state) {
   console.log(`Making badge: ${badge[FILE_KEY]}.${state.format}`)
   const svg = bf.create(state)
-  makeFolderIfNotExists(badge)
+  makeFolderIfNotExists(state)
 
-  const folderName = badge[FOLDER_KEY]
+  const folderName = state[FOLDER_KEY]
   const fileName = `${badge[FILE_KEY]}.${state.format}`
 
   const currentDirectory = process.cwd()

--- a/lib/makeBadge.test.js
+++ b/lib/makeBadge.test.js
@@ -24,8 +24,8 @@ describe('makeBadge function', () => {
   it('should create a badge and write it to file', () => {
     makeBadge({
       [FILE_KEY]: 'badge-name',
-      [FOLDER_KEY]: 'testFolder/someOtherFolder',
     }, {
+      [FOLDER_KEY]: 'testFolder/someOtherFolder',
       format: 'svg',
       template: 'plastic',
       colorA: '#fff',
@@ -38,8 +38,8 @@ describe('makeBadge function', () => {
   it('should return an svg output', () => {
     expect(makeBadge({
       [FILE_KEY]: 'badge-name',
-      [FOLDER_KEY]: 'testFolder/someOtherFolder',
     }, {
+      [FOLDER_KEY]: 'testFolder/someOtherFolder',
       format: 'svg',
       template: 'for-the-badge',
       colorA: '#faf',

--- a/lib/utils/verifyBadge.js
+++ b/lib/utils/verifyBadge.js
@@ -1,4 +1,4 @@
-const { FILE_KEY, FOLDER_KEY } = require('../constants/defaults')
+const { FILE_KEY } = require('../constants/defaults')
 const { getRealType } = require('./getRealType')
 
 const has = Object.prototype.hasOwnProperty
@@ -11,10 +11,6 @@ function verifyBadge(badge) {
 
   if (!has.call(badge, FILE_KEY)) {
     throw new Error(`Badge item is missing a ${FILE_KEY} property`)
-  }
-
-  if (!has.call(badge, FOLDER_KEY)) {
-    throw new Error(`Badge item is missing a ${FOLDER_KEY} property`)
   }
 
   return null

--- a/lib/utils/verifyBadge.test.js
+++ b/lib/utils/verifyBadge.test.js
@@ -11,13 +11,13 @@ describe('verifyBadge function', () => {
     }
     expect(func).toThrowError(`Badge item is missing a ${FILE_KEY} property`)
   })
-  it('should throw an error if missing FOLDER_KEY property', () => {
+  it('should NOT throw an error if missing FOLDER_KEY property', () => {
     const func = () => {
       verifyBadge({
         [FILE_KEY]: 'my-badge-name',
       })
     }
-    expect(func).toThrowError(`Badge item is missing a ${FOLDER_KEY} property`)
+    expect(func).not.toThrowError(`Badge item is missing a ${FOLDER_KEY} property`)
   })
   it('should throw an error if badge is not an object', () => {
     const func = () => { verifyBadge(7) }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-badges",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "a tool that generates badges locally from a customizable configuration file",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Type of change

new feature

### Description of the change
TESTS MODIFIED

Prior to this change, the folder property would only have been read by local-badges if it came from the badge object directly ie:
```js
const badges = [
    {
        name: 'some-badge',
        folder: './'
    }
]
```
So if you had something like:
```js
module.exports = {
    badges: [
        {
             name: 'some-badge',
        }
    ],
    defaults: {
        folder: 'myFolder'
    }
}
```
It would fail because it could not find a folder property in the badge object.
This PR changes that, and now allows you to override the folder property just like any other default property. An example of the new functionality can be shown as follows:
```js
module.exports = {
    badges: [
        {
             name: 'some-badge',
             folder: 'override1',
             fn: (cliObj) => {
                 return {
                     folder: 'override2',
                 },
             },
        }
    ],
    defaults: {
        folder: 'myFolder',
    }
}
```
Originally, local-badges will say the folder is './' because that is a global default. The first thing local-badges checks for is whether or not there is a defaults property in your configuration, which there is in this case. local-badges will store the folder as 'myFolder'. Next, it sees that there is a folder property in the badge object called 'override1', so it replaces 'myFolder' with 'override1'. And finally, it runs the users function, which returns folder: 'override2', so local-badges replaces 'override1' with 'override2', and the badge will be created in ./override2/some-badge.svg

### Link to issue(s)

Relevant issue: #4 